### PR TITLE
Fix the incorrect usage of slice copy in petrelc.

### DIFF
--- a/petrel/book.go
+++ b/petrel/book.go
@@ -33,9 +33,7 @@ func newBookServer(pOut, pIn chan packet.Packet, vpnnet string, tun *water.Inter
 }
 
 func (bs *BookServer) start() {
-
 	go bs.listenTun()
-
 	for {
 		p, ok := <-bs.pIn
 		if !ok {
@@ -44,9 +42,13 @@ func (bs *BookServer) start() {
 		}
 		src_ip := waterutil.IPv4Source(p.Data)
 		log.Debug("Book: from client", src_ip)
+		log.Debug("Book: datalen=", len(p.Data))
 
 		bs.book.Add(src_ip.String(), p.Header.Sk)
-		bs.tun.Write(p.Data)
+		_, err := bs.tun.Write(p.Data)
+		if err != nil {
+			log.Error("Error writing to tun!", err)
+		}
 	}
 }
 

--- a/petrelc/local.go
+++ b/petrelc/local.go
@@ -38,8 +38,8 @@ func startListenTun(pIn, pOut chan packet.Packet, ip net.IP) error {
 
 /* handle traffic from client to target */
 func handleTunOut(tun *water.Interface, pOut chan packet.Packet) {
-	buf := make([]byte, packet.MTU)
 	for {
+		buf := make([]byte, packet.MTU)
 		n, err := tun.Read(buf)
 		if err != nil {
 			log.Error("Reading from tunnel:", err)
@@ -48,6 +48,7 @@ func handleTunOut(tun *water.Interface, pOut chan packet.Packet) {
 
 		p := packet.NewPacket()
 		p.SetData(buf[:n])
+
 		pOut <- *p
 	}
 }

--- a/test/scripts/cnc.sh
+++ b/test/scripts/cnc.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
 display_help () {
-    echo "cnc [COUNT] [PROTOCOL] [TARGET] [PORT]"
+    echo "cnc [COUNT] [PROTOCOL]"
     echo "COUNT: number of bytes to send"
     echo "PROTOCOL: udp or tcp"
-    echo "TARGET: destination address"
-    echo "PORT: destination port"
 }
 
-if [ $# -ne 4 ]; then
+if [ $# -ne 2 ]; then
     echo "Please follow bellow format:"
     display_help
     exit 1
@@ -16,8 +14,6 @@ fi
 
 COUNT=$1
 PROTO=$2
-TARGET=$3
-PORT=$4
 
 if [ $PROTO == "udp" ]; then
     PROTO="-u"
@@ -27,4 +23,4 @@ fi
 
 cd /projects/tinyvpn/scripts
 cat /dev/urandom | base64 | head -c $COUNT > random.in 
-nc -q 1 $PROTO $TARGET $PORT < random.in
+nc -q 1 $PROTO 10.0.5.100 2222 < random.in


### PR DESCRIPTION
This problem caused fragment error (in fact, the whole slice is replaced with the later one) in petrel.